### PR TITLE
convert to vga

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 BDFS = $(wildcard *.bdf)
 PCFS = $(BDFS:%.bdf=%.pcf)
+VGAS = $(BDFS:%.bdf=%.vga)
 
 all: pcfs
 
@@ -8,7 +9,12 @@ pcfs: $(PCFS)
 $(PCFS): %.pcf: %.bdf
 	bdftopcf -o $@ $^
 
+vgas: $(VGAS)
+
+$(VGAS): %.vga: %.bdf
+	ruby bdftovga $^ $@
+
 clean:
-	rm -f *.pcf
+	rm -f *.pcf *.vga
 
 .PHONY: all clean

--- a/bdftovga
+++ b/bdftovga
@@ -1,0 +1,47 @@
+#!/usr/bin/env ruby
+
+if ARGV.length == 2
+  outmap = +("\x00".b * 16 * 256)
+elsif ARGV.length == 3
+  # Use a different font as a base.
+  outmap = File.open(ARGV.shift, "rb", &:read)
+end
+
+state = :lost
+encoding = nil
+ch = nil
+
+def write(outmap, encoding, ch)
+  offset = encoding * 16
+  ch.each.with_index do |c, i|
+    outmap[offset+i] = c.chr.b
+  end
+end
+
+File.readlines(ARGV[0]).each do |line|
+  case state
+  when :lost
+    case line
+    when /\AENCODING (\d+)\n\z/
+      encoding = $1.to_i
+      next if encoding > 255
+      ch = []
+      state = :encoding
+    end
+  when :encoding
+    case line
+    when /\ABITMAP\n\z/
+      state = :bitmap
+    end
+  when :bitmap
+    case line
+    when /\AENDCHAR\n\z/
+      write(outmap, encoding, ch)
+      state = :lost
+    when /\A([0-9a-fA-F]{2})\n\z/
+      ch << $1.to_i(16)
+    end
+  end
+end
+
+File.open(ARGV[1], "wb") { |f| f.write(outmap) }


### PR DESCRIPTION
Adds a small tool to convert the bdf to a file suitable for direct use, per how VGA data can be found online. (There isn't a really good name for this; see [this SO answer to know what I mean](https://retrocomputing.stackexchange.com/a/9217/20624).)

Maybe there was a simpler way to do this? But this worked, so thanks! PR for your interest. A screenshot of it in action (vs. the regular cp437 VGA font).

| cp437 | atarist |
| :-: | :-: |
| <img width="912" alt="cp437" src="https://user-images.githubusercontent.com/1915/105506101-cbd37600-5d1d-11eb-9fd0-c1d641b142ae.png"> | <img width="912" alt="atarist" src="https://user-images.githubusercontent.com/1915/105506106-cd04a300-5d1d-11eb-8e4f-c9c4d330de53.png"> |

